### PR TITLE
Remove apt installation docu for "nymea-plugins"

### DIFF
--- a/src/pages/documentation/users/installation/core.md
+++ b/src/pages/documentation/users/installation/core.md
@@ -63,7 +63,7 @@ Once done so, nymea:core can be installed using apt-get:
 
 ```bash
 sudo apt-get update
-sudo apt-get install nymea nymea-plugins
+sudo apt-get install nymea
 ```
 
 Once this command completes, nymea:core should be up and running on the Raspberry Pi.
@@ -126,7 +126,7 @@ Once done so, nymea:core can be installed using apt-get:
 
 ```bash
 sudo apt-get update
-sudo apt-get install nymea nymea-plugins
+sudo apt-get install nymea
 ```
 
 Once this command completes, nymea:core should be up and running.


### PR DESCRIPTION
As read in some forum posts, it looks like apt package for nymea-plugins is not existing anymore. 