### PR TITLE
Update core.md / Manual installation on a Raspberry Pi / change repo to main instead of rpi

### DIFF
--- a/src/pages/documentation/users/installation/core.md
+++ b/src/pages/documentation/users/installation/core.md
@@ -36,7 +36,7 @@ If the nymea Raspberry Pi image is not used, nymea:core can also be installed on
 To enable the repository, create a file named `/etc/apt/sources.list.d/nymea.list` using the following command:
 
 ```bash
-echo "deb http://repository.nymea.io $(lsb_release -s -c) rpi" | sudo tee /etc/apt/sources.list.d/nymea.list
+echo "deb http://repository.nymea.io $(lsb_release -s -c) main" | sudo tee /etc/apt/sources.list.d/nymea.list
 ```
 
 The packages in the nymea repository are signed with nymeas GPG key which can be imported by running:


### PR DESCRIPTION
In line 39, the repo must be changed to main instead of rpi, as the rpi repository is no longer supported.
So the correct command needs to be the following
echo "deb http://repository.nymea.io $(lsb_release -s -c) main" | sudo tee /etc/apt/sources.list.d/nymea.list